### PR TITLE
Changes in gtfs2gps()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
       doSNOW,
       snow,
       foreach,
-      utils
+      utils,
+      pbapply
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr
 LinkingTo: Rcpp

--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -59,12 +59,19 @@ gtfs2gps <- function(gtfs_data, filepath = NULL, spatial_resolution = 15, progre
 
     spatial_resolution <- units::set_units(spatial_resolution, "m")
     
-    # update stops_seq with snap stops to route shape
-    stops_seq$ref <- cpp_snap_points(stops_sf %>% sf::st_coordinates(), 
+    snapped <- cpp_snap_points(stops_sf %>% sf::st_coordinates(), 
                                      new_shape %>% sf::st_coordinates(),
                                      spatial_resolution,
                                      all_tripids[1])
 
+    if(is.null(snapped) | length(snapped) == 0){
+     # warning(paste0(all_tripids[1], ","))
+      return(NULL)
+    }
+      
+    # update stops_seq with snap stops to route shape
+    stops_seq$ref <- snapped
+      
     ### Start building new stop_times.txt file
 
     # get shape points in high resolution

--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -82,15 +82,12 @@ gtfs2gps <- function(gtfs_data, filepath = NULL, spatial_resolution = 15, progre
     new_stoptimes[, dist := rcpp_distance_haversine(shape_pt_lat, shape_pt_lon, data.table::shift(shape_pt_lat, type = "lead"), data.table::shift(shape_pt_lon, type = "lead"), tolerance = 1e10)]
     new_stoptimes <- na.omit(new_stoptimes, cols = "dist")
 
-    ###### PART 2.2 Function recalculate new stop_times for each trip id of each Shape id ------------------------------------
-    new_stoptimes <- lapply(X = all_tripids, FUN = update_single, new_stoptimes, gtfs_data) %>%
-      data.table::rbindlist()
-    
-    #if(test_gtfs_freq(gtfs_data) == "frequency"){
-    #  new_stoptimes <- lapply(X = all_tripids, FUN = update_freq, new_stoptimes, gtfs_data) %>% data.table::rbindlist()
-    #}else{
-    #  new_stoptimes <- lapply(X = all_tripids, FUN = update_dt, new_stoptimes, gtfs_data) %>% data.table::rbindlist()
-    #}
+    ###### PART 2.2 Function recalculate new stop_times for each trip id of each Shape id ------------------------------
+    if(test_gtfs_freq(gtfs_data) == "frequency"){
+      new_stoptimes <- lapply(X = all_tripids, FUN = update_freq, new_stoptimes, gtfs_data) %>% data.table::rbindlist()
+    }else{
+      new_stoptimes <- lapply(X = all_tripids, FUN = update_dt, new_stoptimes, gtfs_data) %>% data.table::rbindlist()
+    }
 
     if(!is.null(filepath)){ # Write object
       data.table::fwrite(x = new_stoptimes,

--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -11,10 +11,17 @@
 #' with the name equals to its id. In this case, no output is returned.
 #' @param cores Number of cores to be used. Default is 1 (no parallel execution).
 #' @param progress Show a progress bar? Default is TRUE.
+#' @param continue Argument that can be used only with filepath. When TRUE, it
+#' skips processing the shape identifiers that were already saved into files.
+#' It is useful to continue processing a FTGS file that was stopped by some
+#' reason. Default value is FALSE.
 #' @export
-gtfs2gps <- function(gtfs_data, filepath = NULL, spatial_resolution = 15, cores = 1, progress = TRUE){
+gtfs2gps <- function(gtfs_data, filepath = NULL, spatial_resolution = 15, cores = 1, progress = TRUE, continue = FALSE){
   ###### PART 1. Load and prepare data inputs ------------------------------------
 
+  if(continue & is.null(filepath))
+    stop("Cannot use argument 'continue' without passing a 'filepath'.")
+  
   if(class(gtfs_data) == "character")
     gtfs_data <- read_gtfs(gtfszip = gtfs_data)
 
@@ -23,6 +30,12 @@ gtfs2gps <- function(gtfs_data, filepath = NULL, spatial_resolution = 15, cores 
 
   ###### PART 2. Analysing data type ----------------------------------------------
   corefun <- function(shapeid){
+    
+    if(continue){
+      file <- paste0(filepath, "/", shapeid, ".txt")
+      if(file.exists(file)) return(NULL)
+    }
+
     # test
     # all_shapeids <- unique(shapes_sf$shape_id)
     # shapeid <- all_shapeids[1]

--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -66,7 +66,6 @@ gtfs2gps <- function(gtfs_data, filepath = NULL, spatial_resolution = 15, cores 
                                      all_tripids[1])
 
     if(is.null(snapped) | length(snapped) == 0){
-     # warning(paste0(all_tripids[1], ","))
       return(NULL)
     }
       

--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -9,9 +9,10 @@
 #' @param filepath Output file path. As default, the output is returned in R.
 #' When this argument is set, each route is saved into a file within filepath,
 #' with the name equals to its id. In this case, no output is returned.
+#' @param cores Number of cores to be used. Default is 1 (no parallel execution).
 #' @param progress Show a progress bar? Default is TRUE.
 #' @export
-gtfs2gps <- function(gtfs_data, filepath = NULL, spatial_resolution = 15, progress = TRUE){
+gtfs2gps <- function(gtfs_data, filepath = NULL, spatial_resolution = 15, cores = 1, progress = TRUE){
   ###### PART 1. Load and prepare data inputs ------------------------------------
 
   if(class(gtfs_data) == "character")
@@ -109,13 +110,19 @@ gtfs2gps <- function(gtfs_data, filepath = NULL, spatial_resolution = 15, progre
 
   # all shape ids
   all_shapeids <- unique(shapes_sf$shape_id)
-  
-  #output <- lapply(X = all_shapeids, FUN = corefun) %>% data.table::rbindlist()
 
-  output <- pbSapply(3, progress, X = all_shapeids, FUN = corefun)
+  if(cores == 1){
+    if(progress) pbapply::pboptions(type = "txt")
 
-  ### Single core
-  # all_shapeids <- all_shapeids[1:3]
-  # output2 <- pbapply::pblapply(X = all_shapeids, FUN=corefun) %>% data.table::rbindlist()
-  return(output)
+    output <- pbapply::pblapply(X = all_shapeids, FUN = corefun) %>% data.table::rbindlist()
+    
+    if(progress) pbapply::pboptions(type = "none")
+  }
+  else
+    output <- pbSapply(3, progress, X = all_shapeids, FUN = corefun)
+
+  if(is.null(filepath))
+    return(output)
+  else
+    return(NULL)
 }

--- a/man/gtfs2gps.Rd
+++ b/man/gtfs2gps.Rd
@@ -5,7 +5,7 @@
 \title{Convert GTFS to GPS given a spatial resolution}
 \usage{
 gtfs2gps(gtfs_data, filepath = NULL, spatial_resolution = 15,
-  progress = TRUE)
+  cores = 1, progress = TRUE)
 }
 \arguments{
 \item{gtfs_data}{A path to a GTFS file to be converted to GPS, or a GTFS data
@@ -16,6 +16,8 @@ When this argument is set, each route is saved into a file within filepath,
 with the name equals to its id. In this case, no output is returned.}
 
 \item{spatial_resolution}{The spatial resolution in meters. Default is 15m.}
+
+\item{cores}{Number of cores to be used. Default is 1 (no parallel execution).}
 
 \item{progress}{Show a progress bar? Default is TRUE.}
 }

--- a/man/gtfs2gps.Rd
+++ b/man/gtfs2gps.Rd
@@ -5,7 +5,7 @@
 \title{Convert GTFS to GPS given a spatial resolution}
 \usage{
 gtfs2gps(gtfs_data, filepath = NULL, spatial_resolution = 15,
-  cores = 1, progress = TRUE)
+  cores = 1, progress = TRUE, continue = FALSE)
 }
 \arguments{
 \item{gtfs_data}{A path to a GTFS file to be converted to GPS, or a GTFS data
@@ -20,6 +20,11 @@ with the name equals to its id. In this case, no output is returned.}
 \item{cores}{Number of cores to be used. Default is 1 (no parallel execution).}
 
 \item{progress}{Show a progress bar? Default is TRUE.}
+
+\item{continue}{Argument that can be used only with filepath. When TRUE, it
+skips processing the shape identifiers that were already saved into files.
+It is useful to continue processing a FTGS file that was stopped by some
+reason. Default value is FALSE.}
 }
 \description{
 Convert GTFS data to GPS format by sampling points using a

--- a/src/snap_points.cpp
+++ b/src/snap_points.cpp
@@ -38,7 +38,8 @@ Rcpp::NumericVector cpp_snap_points_level(Rcpp::NumericMatrix& data, Rcpp::Numer
     if(level > 3){
       std::stringstream text;
       text << "Could not find a nearest point closer than " << spatial_resolution << "m (eight times spatial_resolution) for id '" << id(0) << "'";
-      stop(text.str());
+      warning(text.str());
+      return NULL;
     }
     
     return cpp_snap_points_level(data, ref, spatial_resolution * 2, level + 1, id);

--- a/src/snap_points.cpp
+++ b/src/snap_points.cpp
@@ -8,14 +8,6 @@ double distanceHaversine(double latf, double lonf, double latt, double lont,
 double toRadians(double deg);
 
 Rcpp::NumericVector cpp_snap_points_level(Rcpp::NumericMatrix& data, Rcpp::NumericMatrix& ref, int spatial_resolution, int level, Rcpp::StringVector id){
-  if(level > 4){
-    double max_dist = spatial_resolution ^ level; 
-
-    std::stringstream text;
-    text << "Could not find a nearest point closer than " << max_dist << "m for id '" << id(0) << "'";
-    stop(text.str());
-  }
-
   Rcpp::NumericVector result_pos;
   
   const int nrow = data.nrow();
@@ -43,6 +35,12 @@ Rcpp::NumericVector cpp_snap_points_level(Rcpp::NumericMatrix& data, Rcpp::Numer
   }
   
   if(total_found < nrow){
+    if(level > 3){
+      std::stringstream text;
+      text << "Could not find a nearest point closer than " << spatial_resolution << "m (eight times spatial_resolution) for id '" << id(0) << "'";
+      stop(text.str());
+    }
+    
     return cpp_snap_points_level(data, ref, spatial_resolution * 2, level + 1, id);
   }
 

--- a/src/snap_points.cpp
+++ b/src/snap_points.cpp
@@ -39,7 +39,7 @@ Rcpp::NumericVector cpp_snap_points_level(Rcpp::NumericMatrix& data, Rcpp::Numer
       std::stringstream text;
       text << "Could not find a nearest point closer than " << spatial_resolution << "m (eight times spatial_resolution) for id '" << id(0) << "'";
       warning(text.str());
-      return NULL;
+      return Rcpp::NumericVector();
     }
     
     return cpp_snap_points_level(data, ref, spatial_resolution * 2, level + 1, id);

--- a/tests/testthat/test_gtfs2gps.R
+++ b/tests/testthat/test_gtfs2gps.R
@@ -44,6 +44,8 @@ test_that("gtfs2gps", {
     # run with a larger dataset
     sp <- system.file("extdata/saopaulo.zip", package="gtfs2gps")
 
+    expect_error(gtfs2gps(sp, continue = TRUE), "Cannot use argument 'continue' without passing a 'filepath'.", fixed = TRUE)
+
     sp_gps <- gtfs2gps(sp, progress = FALSE)
 
     expect_true(all(names(sp_gps) %in% 

--- a/tests/testthat/test_snap_points.R
+++ b/tests/testthat/test_snap_points.R
@@ -19,7 +19,9 @@ test_that("snap_points", {
   
   expect_equal(result, 1)
 
-  expect_error(cpp_snap_points(stops %>% sf::st_coordinates(), matrix(2, 1), res, "abc"), "Could not find a nearest point closer than 245m for id 'abc'")
+  expect_error(cpp_snap_points(stops %>% sf::st_coordinates(), matrix(2, 1), res, "abc"),
+               "Could not find a nearest point closer than 120m (eight times spatial_resolution) for id 'abc'",
+               fixed = TRUE)
 
   # complete test
   gtfs <- read_gtfs(system.file("extdata/poa.zip", package="gtfs2gps")) %>%

--- a/tests/testthat/test_snap_points.R
+++ b/tests/testthat/test_snap_points.R
@@ -19,7 +19,7 @@ test_that("snap_points", {
   
   expect_equal(result, 1)
 
-  expect_error(cpp_snap_points(stops %>% sf::st_coordinates(), matrix(2, 1), res, "abc"),
+  expect_warning(cpp_snap_points(stops %>% sf::st_coordinates(), matrix(2, 1), res, "abc"),
                "Could not find a nearest point closer than 120m (eight times spatial_resolution) for id 'abc'",
                fixed = TRUE)
 


### PR DESCRIPTION
- `cpp_snap_points()` now shows a warning instead of an error to avoid stopping the function. The trips shown in the warning(s) will be ignored in the returned GPS data.
- New arguments `cores` and `continue` to `gtfs2gps()`.
- Simplifying `update_freq`/`update_dt`.
- Fixing the problem for Curitiba data (@Joaobazzo - I have not verified Fortaleza data yet)
