### PR TITLE
Version 1.2-3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,13 @@
 Type: Package
 Package: gtfs2gps
 Title: Converting Transport Data from GTFS Format to GPS-Like Records
-Version: 1.2-2
+Version: 1.2-3
 Authors@R: c(person(given="Rafael H. M.", family="Pereira", email="rafa.pereira.br@gmail.com", role="aut", comment = c(ORCID = "0000-0003-2125-7465")),
             person(given="Pedro R.", family="Andrade", email="pedro.andrade@inpe.br", role=c("aut", "cre"), comment = c(ORCID = "0000-0001-8675-4046")),
             person(given="Joao", family="Bazzo", role="aut", comment = c(ORCID = "0000-0003-4536-5006")),
             person(given="Marcin", family="Stepniak", role="ctb"),
             person("Ipea - Institue for Applied Economic Research", role = c("cph", "fnd")))
-Date: 2020-05-25
+Date: 2020-07-05
 URL: https://github.com/ipeaGIT/gtfs2gps
 BugReports: https://github.com/ipeaGIT/gtfs2gps/issues
 Description: Convert general transit feed specification (GTFS) data to global positioning system (GPS) records in 'data.table' format. It also has some functions to subset GTFS data in time and space and to convert both representations to simple feature format.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gtfs2gps
 Title: Converting Transport Data from GTFS Format to GPS-Like Records
-Version: 1.2-1
+Version: 1.2-2
 Authors@R: c(person(given="Rafael H. M.", family="Pereira", email="rafa.pereira.br@gmail.com", role="aut", comment = c(ORCID = "0000-0003-2125-7465")),
             person(given="Pedro R.", family="Andrade", email="pedro.andrade@inpe.br", role=c("aut", "cre"), comment = c(ORCID = "0000-0001-8675-4046")),
             person(given="Joao", family="Bazzo", role="aut", comment = c(ORCID = "0000-0003-4536-5006")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,6 @@ Imports:
       rgeos,
       sfheaders,
       lwgeom,
-      utils,
       raster,
       pbapply
 RoxygenNote: 7.1.0

--- a/R/filter_gtfs.R
+++ b/R/filter_gtfs.R
@@ -13,7 +13,8 @@
 #' did not have any inconsistency.
 #' @param gtfs_data A list of data.tables read using gtfs2gps::reag_gtfs().
 #' @param only_essential Remove only the essential files? The essential files are all but 
-#' agency and calendar. Default is TRUE, which means that agency-routes and trips-calendar relations
+#' agency, calendar, and routes. Default is TRUE, which means that agency-routes,
+#' routes-trips, and trips-calendar relations
 #' will not be processed as restrictions to remove objects.
 #' @param prompt_invalid Show the invalid objects. Default is FALSE.
 #' @return A subset of the input GTFS data. 
@@ -40,7 +41,7 @@ remove_invalid <- function(gtfs_data, only_essential = TRUE, prompt_invalid = FA
     size <- newsize
     
     # agency-routes relation (agency_id)
-    if(!only_essential && !is.null(gtfs_data$agency)){
+    if(!only_essential && !is.null(gtfs_data$agency) && !is.null(gtfs_data$routes)){
       agency_ids <- intersect(gtfs_data$agency$agency_id, gtfs_data$routes$agency_id)
       removed$agency_ids <- c(removed$agency_ids, setdiff(gtfs_data$agency$agency_id, gtfs_data$routes$agency_id))
 
@@ -49,12 +50,14 @@ remove_invalid <- function(gtfs_data, only_essential = TRUE, prompt_invalid = FA
     }
   
     # routes-trips relation (route_id)
-    route_ids <- intersect(gtfs_data$routes$route_id, gtfs_data$trips$route_id)
-    removed$route_ids <- c(removed$route_ids, setdiff(gtfs_data$routes$route_id, gtfs_data$trips$route_id))
-
-    gtfs_data$routes <- subset(gtfs_data$routes, route_id %in% route_ids)
-    gtfs_data$trips  <- subset(gtfs_data$trips,  route_id %in% route_ids)
+    if(!only_essential && !is.null(gtfs_data$routes)){
+      route_ids <- intersect(gtfs_data$routes$route_id, gtfs_data$trips$route_id)
+      removed$route_ids <- c(removed$route_ids, setdiff(gtfs_data$routes$route_id, gtfs_data$trips$route_id))
   
+      gtfs_data$routes <- subset(gtfs_data$routes, route_id %in% route_ids)
+      gtfs_data$trips  <- subset(gtfs_data$trips,  route_id %in% route_ids)
+    }
+
     # trips-shapes relation (shape_id)
     shape_ids <- intersect(gtfs_data$trips$shape_id, gtfs_data$shapes$shape_id)
     removed$shape_ids <- c(removed$shape_ids, setdiff(gtfs_data$trips$shape_id, gtfs_data$shapes$shape_id))
@@ -136,9 +139,11 @@ filter_by_shape_id <- function(gtfs_data, shape_ids){
   stop_ids <- unique(gtfs_data$stop_times$stop_id)
   gtfs_data$stops <- subset(gtfs_data$stops, stop_id %in% stop_ids)
   
-  route_ids <- unique(gtfs_data$trips$route_id)
-  gtfs_data$routes <- subset(gtfs_data$routes, route_id %in% route_ids)  
-
+  if(!is.null(gtfs_data$routes)){
+    route_ids <- unique(gtfs_data$trips$route_id)
+    gtfs_data$routes <- subset(gtfs_data$routes, route_id %in% route_ids)  
+  }
+  
   return(gtfs_data)
 }
 
@@ -158,6 +163,7 @@ filter_by_shape_id <- function(gtfs_data, shape_ids){
 #' result <- filter_by_agency_id(poa, "EPTC")
 filter_by_agency_id <- function(gtfs_data, agency_ids){
   if(is.null(gtfs_data$agency)) stop("GTFS data does not have agency")
+  if(is.null(gtfs_data$routes)) stop("GTFS data does not have routes")
 
   gtfs_data$agency <- subset(gtfs_data$agency, agency_id %in% agency_ids)
   gtfs_data$routes <- subset(gtfs_data$routes, agency_id %in% agency_ids)
@@ -204,8 +210,10 @@ filter_valid_stop_times <- function(gtfs_data){
   stop_ids <- unique(gtfs_data$stop_times$stop_id)
   gtfs_data$stops <- subset(gtfs_data$stops, stop_id %in% stop_ids)
   
-  route_ids <- unique(gtfs_data$trips$route_id)
-  gtfs_data$routes <- subset(gtfs_data$routes, route_id %in% route_ids)
+  if(!is.null(gtfs_data$routes)){
+    route_ids <- unique(gtfs_data$trips$route_id)
+    gtfs_data$routes <- subset(gtfs_data$routes, route_id %in% route_ids)
+  }
 
   return(gtfs_data)
 }
@@ -250,9 +258,11 @@ filter_single_trip <- function(gtfs_data){
     trip_ids <- unique(gtfs_data$trips$trip_id)
     gtfs_data$frequencies <- subset(gtfs_data$frequencies, trip_id %in% trip_ids)
   }
-    
-  route_ids <- unique(gtfs_data$trips$route_id)
-  gtfs_data$routes <- subset(gtfs_data$routes, route_id %in% route_ids)
+  
+  if(!is.null(gtfs_data$routes)){
+    route_ids <- unique(gtfs_data$trips$route_id)
+    gtfs_data$routes <- subset(gtfs_data$routes, route_id %in% route_ids)
+  }
 
   return(gtfs_data)
 }
@@ -273,6 +283,8 @@ filter_single_trip <- function(gtfs_data){
 #' 
 #' subset <- filter_by_route_type(warsaw, c(0, 3))
 filter_by_route_type <- function(gtfs_data, route_types) {
+  if(is.null(gtfs_data$routes)) stop("GTFS data does not have routes")
+
   gtfs_data$routes <- subset(gtfs_data$routes, route_type %in% route_types)
 
   route_ids <- unique(gtfs_data$routes$route_id)
@@ -310,6 +322,8 @@ filter_by_route_type <- function(gtfs_data, route_types) {
 #' 
 #' subset <- filter_by_route_id(warsaw, c("15", "175"))
 filter_by_route_id <- function(gtfs_data, route_ids) {
+  if(is.null(gtfs_data$routes)) stop("GTFS data does not have routes")
+
   gtfs_data$routes <- subset(gtfs_data$routes, route_id %in% route_ids)
   gtfs_data$trips <- subset(gtfs_data$trips, route_id %in% route_ids) 
 

--- a/R/gps_as_sflinestring.R
+++ b/R/gps_as_sflinestring.R
@@ -39,7 +39,7 @@ gps_as_sflinestring  <- function(gps, crs = 4326){
   id1 <- c(id0[-1], nrow(dt))
 
   # create a data table grouping ids by unique intervals
-  # # Here we create a data.table indicating what are all the point ids in each interval
+  # Here we create a data.table indicating what are all the point ids in each interval
   list_ids <- lapply(seq_along(id0), function(i){data.table::data.table(interval = i, id = (id0[i]:id1[i]))}) %>%
       data.table::rbindlist()
     
@@ -55,7 +55,7 @@ gps_as_sflinestring  <- function(gps, crs = 4326){
   # reorder columns
   dt1 <- data.table::setcolorder(dt1, names(dt))
   
-  # recode their  unique id's so they fall and the end of each interval 
+  # recode their unique id's so they fall and the end of each interval 
   dt1[, c("id", "interval_id") := list(id - 0.1, interval_id - 1)] 
   
   # add extra points in valid_id's of the GPS data

--- a/R/gps_as_sflinestring.R
+++ b/R/gps_as_sflinestring.R
@@ -61,8 +61,8 @@ gps_as_sflinestring  <- function(gps, crs = 4326){
   # add extra points in valid_id's of the GPS data
   dt2 <- data.table::rbindlist(list(dt, dt1))[order(id)]
   
-  # create unique id for each unique combinarion of interval_id & trip_id
-  dt2[, grp := .GRP, by = .(interval_id, trip_id)]
+  # create unique id for each unique combination of interval_id & trip_id & trip_number
+  dt2[, grp := .GRP, by = .(interval_id, trip_id, trip_number)]
 
   dt2[, .N, by = grp] # number of observations in each grp
   

--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -175,6 +175,10 @@ gtfs2gps <- function(gtfs_data, spatial_resolution = 50, parallel = FALSE, strat
     
     new_stoptimes[, departure_time := data.table::as.ITime(departure_time)]
 
+    data.table::setcolorder(new_stoptimes, c("id", "shape_id", "trip_id", "trip_number", "route_type", 
+      "shape_pt_lon", "shape_pt_lat", "departure_time", "stop_id", "stop_sequence", "dist", "cumdist",
+      "cumtime", "speed"))
+    
     if(!is.null(filepath)){ # Write object
       data.table::fwrite(x = new_stoptimes,
              file = paste0(filepath, "/", shapeid, ".txt"))

--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -200,15 +200,17 @@ gtfs2gps <- function(gtfs_data, spatial_resolution = 50, parallel = FALSE, strat
   }
   else
   {  
-    # message("Preparing parallelization")
-    future::plan(strategy)
-    
     # number of cores
     cores <- data.table::getDTthreads() - 1
     message(paste('Using', cores, 'CPU cores'))
     
+    future::plan(strategy, workers = cores)
+    
     message("Processing the data")
-    output <-  furrr::future_map( .x = all_shapeids, .f = corefun, .progress = progress, .options = furrr::future_options(packages=c('data.table', 'sf', 'magrittr', 'Rcpp', 'sfheaders', 'units'))) %>% data.table::rbindlist()
+    output <- furrr::future_map(.x = all_shapeids, .f = corefun, .progress = progress, 
+      .options = furrr::future_options(
+        packages = c('data.table', 'sf', 'magrittr', 'Rcpp', 'sfheaders', 'units'))) %>% 
+      data.table::rbindlist()
   }
 
   if(is.null(filepath))

--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -173,7 +173,7 @@ gtfs2gps <- function(gtfs_data, spatial_resolution = 50, parallel = FALSE, strat
       return(NULL)  # nocov
     }
     
-    new_stoptimes[, departure_time:= data.table::as.ITime(departure_time)]
+    new_stoptimes[, departure_time := data.table::as.ITime(departure_time)]
 
     if(!is.null(filepath)){ # Write object
       data.table::fwrite(x = new_stoptimes,

--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -205,7 +205,7 @@ gtfs2gps <- function(gtfs_data, spatial_resolution = 50, parallel = FALSE, strat
   else
   {  
     # number of cores
-    cores <- data.table::getDTthreads() - 1
+    cores <- future::availableCores() - 1
     message(paste('Using', cores, 'CPU cores'))
     
     future::plan(strategy, workers = cores)

--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -71,9 +71,6 @@ gtfs2gps <- function(gtfs_data, spatial_resolution = 50, parallel = FALSE, strat
 
     # identify route id
     routeid <- gtfs_data$trips[shape_id == shapeid]$route_id[1]
-
-    # identify route type
-    routetype <- gtfs_data$routes[route_id == routeid]$route_type
     
     # get all trips linked to that route
     all_tripids <- gtfs_data$trips[shape_id == shapeid & route_id == routeid, ]$trip_id %>% unique()
@@ -140,10 +137,15 @@ gtfs2gps <- function(gtfs_data, spatial_resolution = 50, parallel = FALSE, strat
     # get shape points in high resolution
     new_stoptimes <- data.table::data.table(shape_id = new_shape$shape_id[1],
                                             id = 1:nrow(new_shape),
-                                            route_type = routetype,
                                             shape_pt_lon = sf::st_coordinates(new_shape)[,1],
                                             shape_pt_lat = sf::st_coordinates(new_shape)[,2])
     
+    # identify route type
+    if(!is.null(gtfs_data$routes)){
+      routetype <- gtfs_data$routes[route_id == routeid]$route_type
+      new_stoptimes[stops_seq$ref, "route_type"] <- routetype
+    }
+
     ## Add stops to new_stoptimes  
     new_stoptimes[stops_seq$ref, "stop_id"] <- stops_seq$stop_id
     new_stoptimes[stops_seq$ref, "stop_sequence"] <- stops_seq$stop_sequence

--- a/R/mod_updates.R
+++ b/R/mod_updates.R
@@ -18,7 +18,7 @@ update_freq <- function(tripid, new_stoptimes, gtfs_data, all_tripids){
   if(dim(freq_temp)[1] == 0) return(new_stoptimes)
   
   # number of trips
-  freq_temp[, service_duration := end_time[1] - start_time[1]]
+  freq_temp[, service_duration := abs(end_time[1] - start_time[1])]
   freq_temp[, number_of_departures := ceiling(service_duration / headway_secs)]
   
   # get all start times of each period
@@ -52,7 +52,7 @@ update_freq <- function(tripid, new_stoptimes, gtfs_data, all_tripids){
       return(NULL)
     }
 
-    if(nmber_of_departures < 0) nmber_of_departures <- -nmber_of_departures
+#    if(nmber_of_departures < 0) nmber_of_departures <- -nmber_of_departures
       
     # list of departures
     departure_list <- 1:nmber_of_departures

--- a/R/mod_updates.R
+++ b/R/mod_updates.R
@@ -39,7 +39,11 @@ update_freq <- function(tripid, new_stoptimes, gtfs_data, all_tripids){
     # Get headway of each start_time
     thisheadway <- subset(freq_temp, start_time == starttimes[1])$headway_secs
     nmber_of_departures <- subset(freq_temp, start_time == starttimes[1])$number_of_departures
-    
+
+    if(length(nmber_of_departures) == 0 || is.na(nmber_of_departures)){
+      warning(paste0("Trip '", tripid, "' has zero departures. Ignoring it."),  call. = FALSE) # nocov
+      return(NULL)
+    }
     # list of departures
     
     departure_list <- 1:nmber_of_departures

--- a/R/mod_updates.R
+++ b/R/mod_updates.R
@@ -44,8 +44,10 @@ update_freq <- function(tripid, new_stoptimes, gtfs_data, all_tripids){
       warning(paste0("Trip '", tripid, "' has zero departures. Ignoring it."),  call. = FALSE) # nocov
       return(NULL)
     }
+
+    if(nmber_of_departures < 0) nmber_of_departures <- -nmber_of_departures
+      
     # list of departures
-    
     departure_list <- 1:nmber_of_departures
     
     # # Replicate one new_stop_times for each departure  

--- a/R/mod_updates.R
+++ b/R/mod_updates.R
@@ -19,7 +19,7 @@ update_freq <- function(tripid, new_stoptimes, gtfs_data, all_tripids){
   
   # functions
   update_newstoptimes <- function(starttimes, freq_temp){
-    update_departure_stoptimes <- function(i, dt_list){ #,dt_list,thisheadway,starttime
+    update_departure_stoptimes <- function(i, dt_list){
       # Update 1st departure time
       dt_list[[i]][ departure_time == data.table::first(departure_time),
                     departure_time := starttimes[1]]
@@ -58,7 +58,7 @@ update_freq <- function(tripid, new_stoptimes, gtfs_data, all_tripids){
     dt_list <- lapply(departure_list, update_departure_stoptimes, dt_list)
     
     # Apply function and return the stop times of all departures from that period
-    departure_stoptimes <- lapply(X =seq_along(dt_list), FUN = update_departure_stoptimes,dt_list) %>%
+    departure_stoptimes <- lapply(X = seq_along(dt_list), FUN = update_departure_stoptimes, dt_list) %>%
       data.table::rbindlist()
     
     #departure_stoptimes <- lapply(X = departure_list, FUN = update_departure_stoptimes) %>% data.table::rbindlist()

--- a/R/mod_updates.R
+++ b/R/mod_updates.R
@@ -1,6 +1,12 @@
 update_freq <- function(tripid, new_stoptimes, gtfs_data, all_tripids){
   # Update new_stoptimes
   new_stoptimes <- update_dt(tripid, new_stoptimes, gtfs_data, all_tripids)
+
+  if(is.null(new_stoptimes)){
+    warning(paste0("Could not create stop times for trip '", tripid, "'. Ignoring it."),  call. = FALSE) # nocov
+    return(NULL) # nocov
+  }
+
   new_stoptimes[, "trip_number"] <- 1
   
   if(is.null(gtfs_data$frequencies)) return(new_stoptimes)

--- a/R/mod_updates.R
+++ b/R/mod_updates.R
@@ -1,6 +1,7 @@
 update_freq <- function(tripid, new_stoptimes, gtfs_data, all_tripids){
   # Update new_stoptimes
   new_stoptimes <- update_dt(tripid, new_stoptimes, gtfs_data, all_tripids)
+  new_stoptimes[, "trip_number"] <- 1
   
   if(is.null(gtfs_data$frequencies)) return(new_stoptimes)
   
@@ -30,7 +31,7 @@ update_freq <- function(tripid, new_stoptimes, gtfs_data, all_tripids){
       
       # Updating all stop times by adding the headway
       dt_list[[i]][, departure_time := round(departure_time + ((i - 1) * thisheadway))]
-
+      dt_list[[i]][, trip_number := i]
       return(dt_list[[i]])
     }
     

--- a/R/read_gtfs.R
+++ b/R/read_gtfs.R
@@ -1,8 +1,8 @@
 #' @title Read GTFS data into a list of data.tables
 #' @description Read files of a zipped GTFS feed and load them to memory as a list of data.tables.
-#' It will load the following files: "agency.txt", "calendar.txt", "shapes.txt", "routes.txt", "shapes.txt", 
-#' "stop_times.txt", "stops.txt", "trips.txt", and "frequencies.txt", with
-#' this last one being optional. If one of the mandatory files does not exit,
+#' It will load the following files: "shapes.txt", "stop_times.txt", "stops.txt", "trips.txt",
+#' "agency.txt", "calendar.txt", "routes.txt", and "frequencies.txt", with
+#' this last four being optional. If one of the mandatory files does not exit,
 #' this function will stop with an error message.
 #' @param gtfszip A zipped GTFS data.
 #' @return A list of data.tables, where each index represents the respective GTFS file name.

--- a/R/read_gtfs.R
+++ b/R/read_gtfs.R
@@ -25,7 +25,7 @@ read_gtfs <- function(gtfszip){
 
   # read files to memory
   if("agency.txt"      %in% unzippedfiles){result$agency      <- myread("agency.txt")}
-  if("routes.txt"      %in% unzippedfiles){result$routes      <- myread("routes.txt")}     else{stop("File routes.txt is missing")}
+  if("routes.txt"      %in% unzippedfiles){result$routes      <- myread("routes.txt")}
   if("stops.txt"       %in% unzippedfiles){result$stops       <- myread("stops.txt")}      else{stop("File stops.txt is missing")}
   if("stop_times.txt"  %in% unzippedfiles){result$stop_times  <- myread("stop_times.txt")} else{stop("File stop_times.txt is missing")}
   if("shapes.txt"      %in% unzippedfiles){result$shapes      <- myread("shapes.txt")}     else{stop("File shapes.txt is missing")}
@@ -37,8 +37,7 @@ read_gtfs <- function(gtfszip){
   if(is.null(result$trips)      || dim(result$trips)[1] == 0)      stop("trips.txt is empty in the GTFS file")
   if(is.null(result$stops)      || dim(result$stops)[1] == 0)      stop("stops.txt is empty in the GTFS file")
   if(is.null(result$stop_times) || dim(result$stop_times)[1] == 0) stop("stop_times.txt is empty in the GTFS file")
-  if(is.null(result$routes)     || dim(result$routes)[1] == 0)     stop("routes.txt is empty in the GTFS file")
-  
+
   mysub <- function(value) sub("^24:", "00:", value)
     
   result$stop_times[, departure_time := data.table::as.ITime(mysub(departure_time), format = "%H:%M:%OS")]

--- a/R/simplify_shapes.R
+++ b/R/simplify_shapes.R
@@ -2,7 +2,7 @@
 #' @title Simplify shapes of a GTFS file
 #'
 #' @description Remove points from the shapes of a GTFS file in order to
-#' reduce its size. It uses Douglas-Peucker algotithm internally.
+#' reduce its size. It uses Douglas-Peucker algorithm internally.
 #'
 #' @param gtfs_data A list of data.tables read using gtfs2gps::reag_gtfs().
 #' @param tol Numerical tolerance value to be used by the Douglas-Peuker algorithm.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -29,5 +29,5 @@ if(getRversion() >= "2.15.1") utils::globalVariables(
     '.N', 'update_newstoptimes', 'shape_pt_sequence', 'geometry',
     'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday',
     'service_duration', 'headway_secs', 'number_of_departures',
-    'cumtime', 'speed', 'i', 'route_type',
+    'cumtime', 'speed', 'i', 'route_type', 'trip_number',
     '.I', 'interval_id', 'i.interval', '.SD', 'grp', '.GRP'))

--- a/man/read_gtfs.Rd
+++ b/man/read_gtfs.Rd
@@ -14,9 +14,9 @@ A list of data.tables, where each index represents the respective GTFS file name
 }
 \description{
 Read files of a zipped GTFS feed and load them to memory as a list of data.tables.
-It will load the following files: "agency.txt", "calendar.txt", "shapes.txt", "routes.txt", "shapes.txt", 
-"stop_times.txt", "stops.txt", "trips.txt", and "frequencies.txt", with
-this last one being optional. If one of the mandatory files does not exit,
+It will load the following files: "shapes.txt", "stop_times.txt", "stops.txt", "trips.txt",
+"agency.txt", "calendar.txt", "routes.txt", and "frequencies.txt", with
+this last four being optional. If one of the mandatory files does not exit,
 this function will stop with an error message.
 }
 \examples{

--- a/man/remove_invalid.Rd
+++ b/man/remove_invalid.Rd
@@ -10,7 +10,8 @@ remove_invalid(gtfs_data, only_essential = TRUE, prompt_invalid = FALSE)
 \item{gtfs_data}{A list of data.tables read using gtfs2gps::reag_gtfs().}
 
 \item{only_essential}{Remove only the essential files? The essential files are all but 
-agency and calendar. Default is TRUE, which means that agency-routes and trips-calendar relations
+agency, calendar, and routes. Default is TRUE, which means that agency-routes,
+routes-trips, and trips-calendar relations
 will not be processed as restrictions to remove objects.}
 
 \item{prompt_invalid}{Show the invalid objects. Default is FALSE.}

--- a/man/simplify_shapes.Rd
+++ b/man/simplify_shapes.Rd
@@ -17,7 +17,7 @@ A GTFS data whose shapes is a subset of the input data.
 }
 \description{
 Remove points from the shapes of a GTFS file in order to
-reduce its size. It uses Douglas-Peucker algotithm internally.
+reduce its size. It uses Douglas-Peucker algorithm internally.
 }
 \examples{
 poa <- read_gtfs(system.file("extdata/poa.zip", package="gtfs2gps"))

--- a/tests/testthat/test_gtfs2gps.R
+++ b/tests/testthat/test_gtfs2gps.R
@@ -19,9 +19,11 @@ test_that("gtfs2gps", {
     expect_equal(my_length, 0)
     
     expect_equal(sum(poa_gps$dist), 4065236, 0.001)
-    
+
+    expect_true(all(poa_gps$trip_number == 1))
+        
     expect_true(all(names(poa_gps) %in% 
-      c("trip_id", "route_type", "id", "shape_pt_lon", "shape_pt_lat",
+      c("trip_id", "route_type", "id", "shape_pt_lon", "shape_pt_lat", "trip_number",
         "departure_time", "stop_id", "stop_sequence", "dist", "shape_id", "cumdist", "speed", "cumtime")))
     
     expect_true(all(!is.na(poa_gps$dist)))
@@ -67,9 +69,11 @@ test_that("gtfs2gps", {
       gtfs2gps(parallel = FALSE, progress = TRUE, spatial_resolution = 15)
 
     expect_true(all(names(sp_gps) %in% 
-      c("trip_id", "route_type", "id", "shape_pt_lon", "shape_pt_lat",
+      c("trip_id", "route_type", "id", "shape_pt_lon", "shape_pt_lat", "trip_number",
         "departure_time", "stop_id", "stop_sequence", "dist", "shape_id", "cumdist", "speed", "cumtime")))
 
+    expect_true(all(sp_gps$trip_number %in% 1:4))
+    
     my_dim <- dim(sp_gps)[1]
     expect_equal(my_dim, 286838)
 

--- a/tests/testthat/test_read_gtfs.R
+++ b/tests/testthat/test_read_gtfs.R
@@ -30,9 +30,10 @@ test_that("read_gtfs", {
 
     unzip("poa.zip")
 
-    files <- c("routes.txt", "stops.txt", "stop_times.txt", "shapes.txt", "trips.txt", "calendar.txt", "agency.txt")
+    # the last three will be ignored in the tests but need to be removed
+    files <- c("stops.txt", "stop_times.txt", "shapes.txt", "trips.txt", "calendar.txt", "agency.txt", "routes.txt")
 
-    for(i in 1:(length(files)-2)){
+    for(i in 1:(length(files) - 3)){
       if(file.exists("myfile.zip")) file.remove("myfile.zip")
       zip("myfile.zip", files[-i], flags = "-q")
       expect_error(read_gtfs("myfile.zip"), paste("File", files[i], "is missing"))
@@ -41,7 +42,7 @@ test_that("read_gtfs", {
     file.remove("myfile.zip")
     file.remove(files)
 
-    empty_files <- c("routes.txt", "stops.txt", "stop_times.txt", "shapes.txt", "trips.txt")
+    empty_files <- c("stops.txt", "stop_times.txt", "shapes.txt", "trips.txt")
 
     for(i in 1:length(empty_files)){
       unzip("poa.zip")

--- a/vignettes/intro_to_gtfs2gps.Rmd
+++ b/vignettes/intro_to_gtfs2gps.Rmd
@@ -9,7 +9,7 @@ vignette: |
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteIndexEntry{gtfs2gps}
 ---
-27 March 2020
+06 July 2020
 
 # Introduction 
 
@@ -33,29 +33,24 @@ sao$trips
 ```
 
 Note that not all GTFS files are loaded into R. This function only loads the necessary data to spatially and temporally handle trips and stops, which are:
-- agency.txt
-- calendar.txt
-- routes.txt
-- shapes.txt
-- stop_times.txt
-- stops.txt
-- trips.txt
-- frequencies.txt (this last one is optional).
-
+"shapes.txt", "stop_times.txt", "stops.txt", "trips.txt",
+"agency.txt", "calendar.txt", "routes.txt", and "frequencies.txt", with
+this last four being optional.
 If a given GTFS zipped file does not contain all of these required files then `read_gtfs()` will stop with an error.
-
 
 # Subsetting GTFS Data
 
 GTFS data sets can be fairly large for complex public transport networks and, in some cases, users might want to focus on specific transport services at week days/weekends, or on specific trips or routes. The package brings some functions to filter GTFS.zip and speed up the data processing.
 
-
-\begin{description}
-\item[filter\_by\_shape\_id():] Filter shapes using given shape ids.
-\item[filter\_valid\_stop\_times():] Return only stop times that have geospatial locations.
-\item[filter\_week\_days():] Remove weekend trips.
-\item[filter\_single\_trip():] Return only one trip per shape\_id.
-\end{description}
+* **filter_by_shape_id():** Filter shapes using given shape ids.
+* **filter_by_agency_id():**  Filter routes using given agency ids.
+* **filter_valid_stop_times():** Return only stop times that have geospatial locations.
+* **filter_week_days():** Remove weekend trips.
+* **filter_single_trip():** Return only one trip per shape_id.
+* **filter_by_route_type():** Filter by transport mode.
+* **filter_by_route_id():** Filter routes and trips by route id.
+* **filter_day_period():** Filter according to a time interval.
+* **remove_invalid():** Remove all inconsistent data, checking all relations.
 
 These functions subset all the relevant GTFS files in order to remove all the unnecessary rows, keeping the data consistent. The returning values of the four functions is a list of `data.table` objects, in the same way of the input data. For example, in the code below we filter only shape ids between 53000 and 53020.
 
@@ -75,7 +70,6 @@ plot(sf::st_geometry(sao_small_shapes_sf))
 plot(sf::st_geometry(sao_small_stops_sf), pch = 20, col = "red", add = TRUE)
 box()
 ```
-
 
 After subsetting the data, it is also possible to save it as a new GTFS file using `write_gtfs()`, as shown below.
 
@@ -128,7 +122,7 @@ For a given trip, the function `gtfs2gps` calculates the average speed between e
 
 $$Large Speed_i = \frac{S_{i+1}-S_i}{t_{i+1}-t_i}$$
 
-Since the beginning of each trip usually starts before the first stop_id, the mean speed cannot be calculated as shown in the previous equation because information on `i` period does not exist. In this case, the function consider the mean speed for the whole trip. It also happens after the last valid stop_id (`N`) of the trips, where info on `i+1` also does not exist. 
+Since the beginning of each trip usually starts before the first stop_id, the mean speed cannot be calculated as shown in the previous equation because information on `i` period does not exist. In this case, the function consider the mean speed for the whole trip. It also happens after the last valid stop_id (`N`) of the trips, where info on `i + 1` also does not exist. 
 
 ```{r speed, echo = FALSE, message = FALSE}
 knitr::include_graphics("https://github.com/ipeaGIT/gtfs2gps/blob/master/man/figures/speed.PNG")

--- a/vignettes/intro_to_gtfs2gps.md
+++ b/vignettes/intro_to_gtfs2gps.md
@@ -1,10 +1,7 @@
-gtfs2gps: Converting GTFS data to GPS-like format
-================
-Rafael H. M. Pereira, Pedro R. Andrade, Joao Bazzo
+06 July 2020
 
-15 December 2019
-
-# Introduction
+Introduction
+============
 
 Package `gtfs2gps` allows users to convert public transport GTFS data
 into a single `data.table` format with GPS-like records, which can then
@@ -12,29 +9,25 @@ be used in various applications such as running transport simulations or
 scenario analyses. Before using the package, just install it from
 GitHub.
 
-``` r
-install.packages("gtfs2gps")
-```
+    install.packages("gtfs2gps")
 
-# Loading data
+Loading data
+============
 
 After loading the package, GTFS data can be read into R by using
 `read_gtfs()`. This function gets a zipped GTFS file and returns a list
 of `data.table` objects. The returning list contains the data of each
 GTFS file indexed according to their file names without extension.
 
-``` r
-library("gtfs2gps")
-sao <- read_gtfs(system.file("extdata/saopaulo.zip", package ="gtfs2gps"))
-names(sao)
-```
+    library("data.table")
+    library("gtfs2gps")
+    sao <- read_gtfs(system.file("extdata/saopaulo.zip", package ="gtfs2gps"))
+    names(sao)
 
     ## [1] "agency"      "routes"      "stops"       "stop_times"  "shapes"     
     ## [6] "trips"       "calendar"    "frequencies"
 
-``` r
-sao$trips
-```
+    sao$trips
 
     ##      route_id service_id   trip_id    trip_headsign direction_id shape_id
     ##   1:  121G-10        USD 121G-10-0   Metrô Tucuruvi            0    52421
@@ -51,14 +44,14 @@ sao$trips
 
 Note that not all GTFS files are loaded into R. This function only loads
 the necessary data to spatially and temporally handle trips and stops,
-which are: - agency.txt - calendar.txt - routes.txt - shapes.txt -
-stop\_times.txt - stops.txt - trips.txt - frequencies.txt (this last one
-is optional).
+which are: “shapes.txt”, “stop\_times.txt”, “stops.txt”, “trips.txt”,
+“agency.txt”, “calendar.txt”, “routes.txt”, and “frequencies.txt”, with
+this last four being optional. If a given GTFS zipped file does not
+contain all of these required files then `read_gtfs()` will stop with an
+error.
 
-If a given GTFS zipped file does not contain all of these required files
-then `read_gtfs()` will stop with an error.
-
-# Subsetting GTFS Data
+Subsetting GTFS Data
+====================
 
 GTFS data sets can be fairly large for complex public transport networks
 and, in some cases, users might want to focus on specific transport
@@ -66,49 +59,52 @@ services at week days/weekends, or on specific trips or routes. The
 package brings some functions to filter GTFS.zip and speed up the data
 processing.
 
+-   **filter\_by\_shape\_id():** Filter shapes using given shape ids.
+-   **filter\_by\_agency\_id():** Filter routes using given agency ids.
+-   **filter\_valid\_stop\_times():** Return only stop times that have
+    geospatial locations.
+-   **filter\_week\_days():** Remove weekend trips.
+-   **filter\_single\_trip():** Return only one trip per shape\_id.
+-   **filter\_by\_route\_type():** Filter by transport mode.
+-   **filter\_by\_route\_id():** Filter routes and trips by route id.
+-   **filter\_day\_period():** Filter according to a time interval.
+-   **remove\_invalid():** Remove all inconsistent data, checking all
+    relations.
+
 These functions subset all the relevant GTFS files in order to remove
 all the unnecessary rows, keeping the data consistent. The returning
 values of the four functions is a list of `data.table` objects, in the
 same way of the input data. For example, in the code below we filter
 only shape ids between 53000 and 53020.
 
-``` r
-library(magrittr)
-object.size(sao) %>% format(units = "Kb")
-```
+    library(magrittr)
+    object.size(sao) %>% format(units = "Kb")
 
-    ## [1] "5419.4 Kb"
+    ## [1] "6227.2 Kb"
 
-``` r
-sao_small <- gtfs2gps::filter_by_shape_id(sao, c(51338, 51956, 51657))
-object.size(sao_small) %>% format(units = "Kb")
-```
+    sao_small <- gtfs2gps::filter_by_shape_id(sao, c(51338, 51956, 51657))
+    object.size(sao_small) %>% format(units = "Kb")
 
-    ## [1] "88.5 Kb"
+    ## [1] "105.8 Kb"
 
 We can then easily convert the data to simple feature format and plot
 them.
 
-``` r
-sao_small_shapes_sf <- gtfs2gps::gtfs_shapes_as_sf(sao_small)
-sao_small_stops_sf <- gtfs2gps::gtfs_stops_as_sf(sao_small)
-plot(sf::st_geometry(sao_small_shapes_sf))
-plot(sf::st_geometry(sao_small_stops_sf), pch = 20, col = "red", add = TRUE)
-box()
-```
+    sao_small_shapes_sf <- gtfs2gps::gtfs_shapes_as_sf(sao_small)
+    sao_small_stops_sf <- gtfs2gps::gtfs_stops_as_sf(sao_small)
+    plot(sf::st_geometry(sao_small_shapes_sf))
+    plot(sf::st_geometry(sao_small_stops_sf), pch = 20, col = "red", add = TRUE)
+    box()
 
-![](intro_to_gtfs2gps_files/figure-gfm/sao_small_shapes_sf-1.png)<!-- -->
-
-![](https://github.com/ipeaGIT/gtfs2gps/blob/master/man/figures/sao_small_shapes_sf.jpg)
+![](C:/Users/pedro/AppData/Local/Temp/RtmpQ5iuLn/preview-9b28579a57fb.dir/intro_to_gtfs2gps_files/figure-markdown_strict/sao_small_shapes_sf-1.png)
 
 After subsetting the data, it is also possible to save it as a new GTFS
 file using `write_gtfs()`, as shown below.
 
-``` r
-write_gtfs(sao_small, "sao_small.zip")
-```
+    write_gtfs(sao_small, "sao_small.zip")
 
-# Converting to GPS-like format
+Converting to GPS-like format
+=============================
 
 To convert GTFS to GPS-like format, use `gtfs2gps()`. This is the core
 function of the package. It takes a GTFS zipped file as an input and
@@ -116,83 +112,85 @@ returns a `data.table` where each row represents a ‘GPS-like’ data point
 for every trip in the GTFS file. In summary, this function interpolates
 the space-time position of each vehicle in each trip considering the
 network distance and average speed between stops. The function samples
-the timestamp of each vehicle every \(15m\) by default, but the user can
+the timestamp of each vehicle every 15*m* by default, but the user can
 set a different value in the `spatial_resolution` argument. See the
 example below.
 
-``` r
-  sao_gps <- gtfs2gps("sao_small.zip", progress = FALSE, parallel = FALSE, spatial_resolution = 15)
-  head(sao_gps)
-```
+      sao_gps <- gtfs2gps("sao_small.zip", progress = FALSE, parallel = FALSE, spatial_resolution = 50)
+      head(sao_gps)
 
-    ##      trip_id route_type id shape_pt_lon shape_pt_lat departure_time
-    ## 1: 5010-10-0          3  1    -46.63120    -23.66268       04:00:01
-    ## 2: 5010-10-0          3  2    -46.63117    -23.66273       04:00:02
-    ## 3: 5010-10-0          3  3    -46.63113    -23.66281       04:00:04
-    ## 4: 5010-10-0          3  4    -46.63108    -23.66288       04:00:05
-    ## 5: 5010-10-0          3  5    -46.63103    -23.66299       04:00:07
-    ## 6: 5010-10-0          3  6    -46.63098    -23.66311       04:00:09
-    ##    stop_id stop_sequence      dist   cumdist    speed   cumtime shape_id
-    ## 1: 3703053             1  7.230445  7.230445 26.11298 0.9968071    51338
-    ## 2:      NA            NA  9.184637 16.415083 26.11298 2.2630239    51338
-    ## 3:      NA            NA  9.184637 25.599720 26.11298 3.5292407    51338
-    ## 4:      NA            NA 13.802386 39.402106 26.11298 5.4320717    51338
-    ## 5:      NA            NA 13.802386 53.204492 26.11298 7.3349028    51338
-    ## 6:      NA            NA 13.802386 67.006878 26.11298 9.2377339    51338
+    ##    id shape_id   trip_id trip_number route_type shape_pt_lon shape_pt_lat
+    ## 1:  1    51338 5010-10-0           1          3    -46.63120    -23.66268
+    ## 2:  2    51338 5010-10-0           1         NA    -46.63117    -23.66273
+    ## 3:  3    51338 5010-10-0           1         NA    -46.63108    -23.66288
+    ## 4:  4    51338 5010-10-0           1         NA    -46.63095    -23.66316
+    ## 5:  5    51338 5010-10-0           1         NA    -46.63082    -23.66345
+    ## 6:  6    51338 5010-10-0           1         NA    -46.63111    -23.66364
+    ##    departure_time stop_id stop_sequence      dist    cumdist    cumtime   speed
+    ## 1:       04:00:01 3703053             1  7.230445   7.230445  0.9788103 26.5931
+    ## 2:       04:00:03    <NA>            NA 18.369274  25.599720  3.4655221 26.5931
+    ## 3:       04:00:08    <NA>            NA 34.505965  60.105685  8.1367134 26.5931
+    ## 4:       04:00:13    <NA>            NA 34.505965  94.611650 12.8079046 26.5931
+    ## 5:       04:00:18    <NA>            NA 36.478776 131.090426 17.7461620 26.5931
+    ## 6:       04:00:23    <NA>            NA 36.478776 167.569201 22.6844194 26.5931
 
 The following figure maps the first 100 data points of the sample data
-we processed.
+we processed. They can be converted to `simple feature` points or
+linestring.
 
-``` r
-  shapes_sf <- gps_as_sf(sao_gps)
-  sao_gps60 <- sao_gps[1:100, ]
-  sao_gps60_sf <- gps_as_sf(sao_gps60)
-  plot(sf::st_geometry(sao_gps60_sf), pch = 20)
-  plot(sf::st_geometry(sao_small_shapes_sf), col = "blue", add = TRUE)
-  box()
-```
+      sao_gps60 <- sao_gps[1:100, ]
+      
+      # points
+      sao_gps60_sfpoints <- gps_as_sfpoints(sao_gps60)
+      
+      # linestring
+      sao_gps60_sflinestring <- gps_as_sflinestring(sao_gps60)
 
-![](intro_to_gtfs2gps_files/figure-gfm/unnamed-chunk-6-1.png)<!-- -->
+      # plot
+      plot(sf::st_geometry(sao_gps60_sfpoints), pch = 20)
+      plot(sf::st_geometry(sao_gps60_sflinestring), col = "blue", add = TRUE)
+      box()
 
-![](https://github.com/ipeaGIT/gtfs2gps/blob/master/man/figures/sao_gps60_sf.jpg)<!-- -->
+![](C:/Users/pedro/AppData/Local/Temp/RtmpQ5iuLn/preview-9b28579a57fb.dir/intro_to_gtfs2gps_files/figure-markdown_strict/unnamed-chunk-6-1.png)
 
-The function `gtfs2gps()` automatically recognises whether the GTFS data
+The function `gtfs2gps()` automatically recognizes whether the GTFS data
 brings detailed `stop_times.txt` information or whether it is a
 `frequency.txt` GTFS file. A sample data of a GTFS with detailed
 `stop_times.txt` cab be found below:
 
-``` r
-poa <- system.file("extdata/poa.zip", package ="gtfs2gps")
-poa_gps <- gtfs2gps(poa, progress = FALSE, parallel = FALSE, spatial_resolution = 15)
-poa_gps_sf <- gps_as_sf(poa_gps)
-poa_sf <- read_gtfs(poa) %>% gtfs_shapes_as_sf()
-plot(sf::st_geometry(poa_gps_sf[1:200,]))
-plot(sf::st_geometry(poa_sf), col = "blue", add = TRUE)
-box()
-```
+    poa <- system.file("extdata/poa.zip", package ="gtfs2gps")
 
-![](intro_to_gtfs2gps_files/figure-gfm/unnamed-chunk-7-1.png)<!-- -->
-![](https://github.com/ipeaGIT/gtfs2gps/blob/master/man/figures/poa.jpg)
+    poa_gps <- gtfs2gps(poa, progress = FALSE, parallel = FALSE, spatial_resolution = 50)
 
-# Methodological note
+    poa_gps_sflinestrig <- gps_as_sfpoints(poa_gps)
+
+    plot(sf::st_geometry(poa_gps_sflinestrig[1:200,]))
+
+    box()
+
+![](C:/Users/pedro/AppData/Local/Temp/RtmpQ5iuLn/preview-9b28579a57fb.dir/intro_to_gtfs2gps_files/figure-markdown_strict/unnamed-chunk-7-1.png)
+
+Methodological note
+===================
 
 For a given trip, the function `gtfs2gps` calculates the average speed
-between each pair of stops — given by the ratio between cumulative
-network distance `S` and departure time `t` for a consecutive pair of
-valid stop\_ids (`i`),
+between each pair of consecutive stops — given by the ratio between
+cumulative network distance `S` and departure time `t` for a consecutive
+pair of valid stop\_ids (`i`),
 
-<img src="https://latex.codecogs.com/svg.latex?\Large&space;Speed_i=\frac{S_{i+1}-S_i}{t_{i+1}-t_i}" title="\Large Speed_i = \frac{S_{i+1}-S_i}{t_{i+1}-t_i}" />
+$$Large Speed\_i = \\frac{S\_{i+1}-S\_i}{t\_{i+1}-t\_i}$$
 
 Since the beginning of each trip usually starts before the first
 stop\_id, the mean speed cannot be calculated as shown in the previous
 equation because information on `i` period does not exist. In this case,
 the function consider the mean speed for the whole trip. It also happens
-after the last valid stop\_id (`N`) of the trips, where info on `i+1`
+after the last valid stop\_id (`N`) of the trips, where info on `i + 1`
 also does not exist.
 
-![](https://github.com/ipeaGIT/gtfs2gps/blob/master/man/figures/speed.PNG)<!-- -->
+![](https://github.com/ipeaGIT/gtfs2gps/blob/master/man/figures/speed.PNG)
 
-# Final remarks
+Final remarks
+=============
 
 If you have any suggestions or want to report an error, please visit the
 GitHub page of the package [here](https://github.com/ipeaGIT/gtfs2gps).


### PR DESCRIPTION
- Stop computing gtfs2gps() for a given shape_id when the data has no departures
- Routes are now optional in a GTFS file
- Updates in code that uses future/furrr
- Adding trip_number as an additional column returned from gtfs2gps()
- Reordering columns in gtfs2gps()
- Fixing problem in gps_as_sflinestring that made a trip to connect the ending points
- Documentation updated