### PR TITLE
Speeding up gps_as_sflinestring()

### DIFF
--- a/R/gps_as_sflinestring.R
+++ b/R/gps_as_sflinestring.R
@@ -72,6 +72,7 @@ gps_as_sflinestring  <- function(gps, crs = 4326){
   
   dt2 <- dt2[grp %in% moreThanOne, ]
   dt2[, dist := max(cumdist) - min(cumdist), by = grp]
+  dt2[, departure_time := data.table::as.ITime(departure_time)]
   
   ## convert to linestring
   gps_sf <- sfheaders::sf_linestring(obj = dt2, 
@@ -81,8 +82,10 @@ gps_as_sflinestring  <- function(gps, crs = 4326){
                                               keep = TRUE) %>% sf::st_set_crs(crs)
 
   # edit columns
-  gps_sf$departure_time <- data.table::as.ITime(gps_sf$departure_time)
   gps_sf$grp <- NULL
-
+  gps_sf$grp.1 <- NULL
+  gps_sf$cumdist <- NULL
+  gps_sf$cumtime <- NULL
+  
   return(gps_sf)
 }

--- a/R/gps_as_sflinestring.R
+++ b/R/gps_as_sflinestring.R
@@ -71,7 +71,8 @@ gps_as_sflinestring  <- function(gps, crs = 4326){
   moreThanOne <- which(as.vector(table(dt2$grp)) != 1)
   
   dt2 <- dt2[grp %in% moreThanOne, ]
-
+  dt2[, dist := max(cumdist) - min(cumdist), by = grp]
+  
   ## convert to linestring
   gps_sf <- sfheaders::sf_linestring(obj = dt2, 
                                               x = 'shape_pt_lon',
@@ -81,7 +82,6 @@ gps_as_sflinestring  <- function(gps, crs = 4326){
 
   # edit columns
   gps_sf$departure_time <- data.table::as.ITime(gps_sf$departure_time)
-  gps_sf$dist <- sf::st_length(gps_sf$geometry)
   gps_sf$grp <- NULL
 
   return(gps_sf)


### PR DESCRIPTION
- Using cumdist instead of st_length, which causes an error of 0.6%.
- Removing unnecessary attributes.