### PR TITLE
add message on merge_gtfs function

### DIFF
--- a/R/merge_gtfs_feeds.R
+++ b/R/merge_gtfs_feeds.R
@@ -17,7 +17,10 @@ merge_gtfs_feeds <- function(gtfs_list){
      gtfs_list <- as.list(gtfs_list)
   
   # read all fees separately
-  all_feeds <- lapply(gtfs_list, read_gtfs)
+  all_feeds <- lapply(gtfs_list, function(i){
+    message(paste0("GTFS '", i, "'"))
+    read_gtfs(i)
+  })
   
   create_new_ids <- function(i, id, files){
     values <- function(i, mfile, id)


### PR DESCRIPTION
adding messages makes it easier to check which files are being read
**before**
![Screenshot from 2020-12-07 13-06-46](https://user-images.githubusercontent.com/23303664/101374811-6c182d00-388d-11eb-818a-7be52c117e53.png)
**after**
![Screenshot from 2020-12-07 13-07-25](https://user-images.githubusercontent.com/23303664/101374807-6a4e6980-388d-11eb-8e82-5ecdfe0ebdad.png)