### PR TITLE
changed class() == "character" call to is.character()

### DIFF
--- a/R/gtfs2gps.R
+++ b/R/gtfs2gps.R
@@ -83,7 +83,7 @@ gtfs2gps <- function(gtfs_data,
   original_gtfs_data_arg <- deparse(substitute(gtfs_data))
   
   # Unzipping and reading GTFS.zip file
-  if(class(gtfs_data) == "character"){
+  if(is.character(gtfs_data)){
     message(paste("Unzipping and reading", basename(gtfs_data)))
     gtfs_data <- read_gtfs(gtfszip = gtfs_data)
   }


### PR DESCRIPTION
Hi. Upon new `{gtfsio}` submission I received an e-mail from CRAN saying that the new version would break existing code in `{gtfs2gps}`. This PR fixes the offending line.

Since now gtfs objects inherit both from `gtfs` and `list` explicitly, the previous call (`class(gtfs_data) == "character"`) would result in a sized-2 logical vector, which would in turn result in a warning, since `if` expects a length 1 object. The new call (`is.character()`) always results in a scalar.

This PR doesn't affect the behaviour of the function and shouldn't affect any tests (well, they didn't break when I checked locally). After you merge it I will answer CRAN's email saying that I have contacted you and fixed the offending code, thus `{gtfsio}` new version will probably be accepted (I hope). It would be good to then submit a new patch version of `{gtfs2gps}` to make sure any calls to `gtfs2gps()` don't raise spurious warnings.

Thank you, and sorry for the inconvenience. 