### PR TITLE
Fix for upcoming testthat 3.3.0 release

### DIFF
--- a/tests/testthat/test_gtfs2gps.R
+++ b/tests/testthat/test_gtfs2gps.R
@@ -84,7 +84,7 @@ test_that("gtfs2gps", {
       gtfs2gps(spatial_resolution = 30)
     
     expect_equal(dim(poa_gps_30)[1], 200560)
-    expect(dim(poa_gps_30)[1] > dim(poa_gps)[1], "more spatial_resolution is not decreasing the number of points")
+    expect_true(dim(poa_gps_30)[1] > dim(poa_gps)[1])
     
     # save into file
     poa_simple <- read_gtfs(poa) |>

--- a/tests/testthat/test_simplify_shapes.R
+++ b/tests/testthat/test_simplify_shapes.R
@@ -6,12 +6,11 @@ test_that("simplify_shapes", {
 
     poa_simpl <- simplify_shapes(poa, 1e-5)
 
-    expect(poa_simpl$shapes$shape_id |> unique() |> length(), 4)
+    expect_equal(poa_simpl$shapes$shape_id |> unique() |> length(), 4)
     expect_equal(dim(poa_simpl$shapes)[1], 867)
 
     poa_simpl <- simplify_shapes(poa, 1e-3)
 
-    expect(poa_simpl$shapes$shape_id |> unique() |> length(), 4)
+    expect_equal(poa_simpl$shapes$shape_id |> unique() |> length(), 4)
     expect_equal(dim(poa_simpl$shapes)[1], 115)
 })
-


### PR DESCRIPTION
`expect()` now checks its inputs highlighting that you accidentally used it instead of the correct expectation