### PR TITLE
Update links in README for new ipea git name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gtfs2gps: Converting public transport data from GTFS format to GPS-like records <img align="right" src="man/figures/logo.png" alt="logo" width="180"> 
 
 [![CRAN/METACRAN Version](https://www.r-pkg.org/badges/version/gtfs2gps)](https://CRAN.R-project.org/package=gtfs2gps).[![CRAN/METACRAN Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/gtfs2gps?color=blue)](https://CRAN.R-project.org/package=gtfs2gps)
-[![R-CMD-check](https://github.com/ipeaGIT/gtfs2gps/workflows/R-CMD-check/badge.svg)](https://github.com/ipeaGIT/gtfs2gps/actions)
+[![R-CMD-check](https://github.com/ipea/gtfs2gps/workflows/R-CMD-check/badge.svg)](https://github.com/ipea/gtfs2gps/actions)
 [![Codecov test coverage](https://codecov.io/gh/ipeaGIT/gtfs2gps/branch/master/graph/badge.svg)](https://codecov.io/gh/ipeaGIT/gtfs2gps?branch=master)
 [![Paper](https://img.shields.io/badge/DOI-10.1007%2Fs10109--022--00400--x-blue)](https://link.springer.com/article/10.1007/s10109-022-00400-x)
 
@@ -23,7 +23,7 @@ library(gtfs2gps)
 
 Please see our vignette:
 
-* [gtfs2gps: Converting GTFS data to GPS format](https://ipeagit.github.io/gtfs2gps/articles/intro_to_gtfs2gps.html)
+* [gtfs2gps: Converting GTFS data to GPS format](https://ipea.github.io/gtfs2gps/articles/intro_to_gtfs2gps.html)
 
 
 


### PR DESCRIPTION
Except Codecov, which is still using the old name.